### PR TITLE
fix(dependencies): pin dependencies to exact version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
   },
   "homepage": "https://github.com/jaebradley/tinder-access-token-generator#readme",
   "dependencies": {
-    "@babel/runtime": "^7.4.4",
-    "axios": "^0.18.0",
-    "puppeteer": "^1.15.0"
+    "@babel/runtime": "7.4.4",
+    "axios": "0.18.0",
+    "puppeteer": "1.15.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/src/generateAccessToken.js
+++ b/src/generateAccessToken.js
@@ -21,6 +21,7 @@ async function generateAccessToken({ emailAddress, password }) {
   ] = await Promise.all([
     page.waitForResponse(resp => resp.url().includes('/dialog/oauth')),
     page.click(LOGIN_ID),
+    page.waitForNavigation({ waitUntil: 'networkidle0' }),
   ]);
 
   const responseText = await response.text();

--- a/src/generateAccessToken.js
+++ b/src/generateAccessToken.js
@@ -1,13 +1,15 @@
 import puppeteer from 'puppeteer';
 
-const TINDER_OAUTH_URL = 'https://www.facebook.com/v2.8/dialog/oauth?app_id=464891386855067&channel_url=https%3A%2F%2Fstaticxx.facebook.com%2Fconnect%2Fxd_arbiter%2Fr%2Fd_vbiawPdxB.js%3Fversion%3D44%23cb%3Df213b0a5a606e94%26domain%3Dtinder.com%26origin%3Dhttps%253A%252F%252Ftinder.com%252Ff14b12c5d35c01c%26relation%3Dopener&client_id=464891386855067&display=popup&domain=tinder.com&e2e=%7B%7D&fallback_redirect_uri=200ee73f-9eb7-9632-4fdb-432ed0c670fa&locale=en_US&origin=1&redirect_uri=https%3A%2F%2Fstaticxx.facebook.com%2Fconnect%2Fxd_arbiter%2Fr%2Fd_vbiawPdxB.js%3Fversion%3D44%23cb%3Df20cfec000032b4%26domain%3Dtinder.com%26origin%3Dhttps%253A%252F%252Ftinder.com%252Ff14b12c5d35c01c%26relation%3Dopener%26frame%3Df2cc4d71cc96f9&response_type=token%2Csigned_request&scope=user_birthday%2Cuser_photos%2Cemail%2Cuser_friends%2Cuser_likes&sdk=joey&version=v2.8&ret=login';
-const EMAIL_ID = 'input[name="email"]';
-const PASSWORD_ID = 'input[name="pass"]';
-const LOGIN_ID = 'input[name="login"]';
+const TINDER_OAUTH_URL = 'https://www.facebook.com/v2.6/dialog/oauth?redirect_uri=fb464891386855067%3A%2F%2Fauthorize%2F&scope=user_birthday%2Cuser_photos%2Cuser_education_history%2Cemail%2Cuser_relationship_details%2Cuser_friends%2Cuser_work_history%2Cuser_likes&response_type=token%2Csigned_request&client_id=464891386855067&ret=login&fallback_redirect_uri=221e1158-f2e9-1452-1a05-8983f99f7d6e&ext=1556057433&hash=Aea6jWwMP_tDMQ9y';
+const EMAIL_ID = '#email';
+const PASSWORD_ID = '#pass';
+const LOGIN_ID = '#loginbutton';
+const CONFIRM_SELECTOR = 'button[name="__CONFIRM__"]';
 
 async function generateAccessToken({ emailAddress, password }) {
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
+
   await page.goto(TINDER_OAUTH_URL);
 
   await page.click(EMAIL_ID);
@@ -16,14 +18,17 @@ async function generateAccessToken({ emailAddress, password }) {
   await page.click(PASSWORD_ID);
   await page.keyboard.type(password);
 
-  const [
-    response,
-  ] = await Promise.all([
-    page.waitForResponse(resp => resp.url().includes('/dialog/oauth')),
+  await Promise.all([
+    page.waitForNavigation(),
     page.click(LOGIN_ID),
-    page.waitForNavigation({ waitUntil: 'networkidle0' }),
   ]);
 
+  await page.waitForSelector(CONFIRM_SELECTOR);
+
+  const [response] = await Promise.all([
+    page.waitForResponse(resp => resp.url().endsWith('/dialog/oauth/confirm/')),
+    page.click(CONFIRM_SELECTOR),
+  ]);
   const responseText = await response.text();
   const tokenParameter = 'access_token=';
   const startIndexOfAccessToken = responseText.indexOf(tokenParameter) + tokenParameter.length;


### PR DESCRIPTION
The latest implementation is causing this error

```bash
> { Error: Protocol error (Network.getResponseBody): No resource with given identifier found
    at Promise (/Users/jaebradley/projects/tinder-client/node_modules/puppeteer/lib/Connection.js:183:56)
    at new Promise (<anonymous>)
    at CDPSession.send (/Users/jaebradley/projects/tinder-client/node_modules/puppeteer/lib/Connection.js:182:12)
    at _contentPromise._bodyLoadedPromise.then (/Users/jaebradley/projects/tinder-client/node_modules/puppeteer/lib/NetworkManager.js:617:45)
    at process._tickCallback (internal/process/next_tick.js:68:7)
  -- ASYNC --
    at Response.<anonymous> (/Users/jaebradley/projects/tinder-client/node_modules/puppeteer/lib/helper.js:110:27)
    at /Users/jaebradley/projects/tinder-client/node_modules/tinder-access-token-generator/build/index.cjs.js:1:2353
    at tryCatch (/Users/jaebradley/projects/tinder-client/node_modules/tinder-access-token-generator/node_modules/regenerator-runtime/runtime.js:45:40)
    at Generator.invoke [as _invoke] (/Users/jaebradley/projects/tinder-client/node_modules/tinder-access-token-generator/node_modules/regenerator-runtime/runtime.js:271:22)
    at Generator.prototype.(anonymous function) [as next] (/Users/jaebradley/projects/tinder-client/node_modules/tinder-access-token-generator/node_modules/regenerator-runtime/runtime.js:97:21)
    at asyncGeneratorStep (/Users/jaebradley/projects/tinder-client/node_modules/tinder-access-token-generator/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
    at _next (/Users/jaebradley/projects/tinder-client/node_modules/tinder-access-token-generator/node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
    at process._tickCallback (internal/process/next_tick.js:68:7)
  message:
   'Protocol error (Network.getResponseBody): No resource with given identifier found' }
```

I think it's because I'm waiting for a response but then the page is redirecting so the response body may / may not be read in time.

It looks like the implementation from `v1` still works, so I'm using that instead.